### PR TITLE
Fix tournament page caching

### DIFF
--- a/app/tournament/[id]/page.tsx
+++ b/app/tournament/[id]/page.tsx
@@ -57,3 +57,4 @@ const StandingsPage = async ({
 export default StandingsPage;
 
 export const fetchCache = "force-no-store";
+export const dynamic = "force-dynamic";


### PR DESCRIPTION
## Summary
- disable caching for dynamic tournament pages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884fa3d4220832a99c83c7ff0f04bf5